### PR TITLE
Get rid of WAIT_TIME by injecting event emitter to actions

### DIFF
--- a/bin/topcoder-cli.js
+++ b/bin/topcoder-cli.js
@@ -187,11 +187,11 @@ program
   .description('Let copilot/managers process private task payments')
   .option('-o --copilot <payment>', 'copilot payment.')
   .option('--dev', 'Points to Topcoder development environment')
-  .action(args => {
+  .action(async args => {
     if (args.dev) {
       process.env.NODE_ENV = 'dev'
     }
-    payHandler.handleCommand(program.args)
+    await payHandler.handleCommand(program.args)
   })
 
 // error on unknown commands

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -19,14 +19,6 @@ The following parameters can be set in config files or in env variables:
 | TC_CLIENT_V2CONNECTION | CLIENT_V2CONNECTION     | TC-User-Database                           | TC client connection protocol          |
 | AUTH0_AUDIENCE         | AUTH0_AUDIENCE          | https://m2m.topcoder.com/                  | AUTH0 Audience (For M2M)               |
 
-# Configuration for Test
-Configuration for test is at `test/common/testConfig.js`.
-The following parameters can be set in config files or in env variables:
-
-| Property  | Environment varible | Default value | Description                                                                   |
-| ---       | ---                 | ---           | ---                                                                           |
-| WAIT_TIME | WAIT_TIME           | 500           | Waiting time for the CLI tool to process subcommands. Increase the value if needed |
-
 # Publish the package to npm
 - Create a npm account on https://www.npmjs.com/signup if you don't have one.
 - Use the account to sign in via cli: `npm login`

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "homepage": "https://topcoder-platform.github.io/topcoder-cli/",
   "devDependencies": {
     "chai": "^4.2.0",
-    "delay": "^4.3.0",
     "mocha": "^6.1.4",
     "mocha-prepare": "^0.1.0",
     "mock-require": "^3.0.3",

--- a/src/commands/pay.js
+++ b/src/commands/pay.js
@@ -5,7 +5,7 @@ const logger = require('../common/logger')
  * Handles the "pay" command
  * @param {Array} args Arguments
  */
-function handleCommand (args) {
+async function handleCommand (args) {
   const options = args[0].opts()
   const challengeDetails = [
     {
@@ -45,7 +45,7 @@ function handleCommand (args) {
     logger.info(response)
     // => response => { username, age, about }
   }
-  promptQuestions()
+  await promptQuestions()
 }
 
 module.exports = {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,13 +1,11 @@
 /*
  * Test CLI functionalities.
  */
-const delay = require('delay')
 const chai = require('chai')
 const _ = require('lodash')
 
 const { program, docs } = require('../bin/topcoder-cli')
 const testHelper = require('./common/testHelper')
-const testConfig = require('./common/testConfig')
 
 const localTestData = {
   argsWithHelp: testHelper.buildArgs(undefined, { help: true }),
@@ -57,31 +55,26 @@ describe('CLI Test', async function () {
 
   it('It should show general help info', async function () {
     program.parse(localTestData.argsWithHelp)
-    await delay(testConfig.WAIT_TIME)
     chai.expect(_.last(messages)).to.include('Topcoder CLI to interact with Topcoder systems')
   })
 
   it('It should show help documentation for command submit', async function () {
     program.parse(localTestData.argsForCommandSubmit)
-    await delay(testConfig.WAIT_TIME)
     chai.expect(_.last(messages)).to.equal(docs.submit)
   })
 
   it('It should show help documentation for command fetch-submissions', async function () {
     program.parse(localTestData.argsForCommandFetchSubmissions)
-    await delay(testConfig.WAIT_TIME)
     chai.expect(_.last(messages)).to.equal(docs['fetch-submissions'])
   })
 
   it('It should show help documentation for command fetch-artifacts', async function () {
     program.parse(localTestData.argsForCommandFetchArtifacts)
-    await delay(testConfig.WAIT_TIME)
     chai.expect(_.last(messages)).to.equal(docs['fetch-artifacts'])
   })
 
   it('failure - It should handle unknown commands', async function () {
     program.parse(localTestData.argsWithUnknownCommand)
-    await delay(testConfig.WAIT_TIME)
     chai.expect(_.last(errorMessages)).to.include('Invalid command:')
   })
 })

--- a/test/common/testConfig.js
+++ b/test/common/testConfig.js
@@ -1,7 +1,0 @@
-/*
- * Configuration for test.
- */
-
-module.exports = {
-  WAIT_TIME: process.env.WAIT_TIME || 500
-}

--- a/test/config.command.test.js
+++ b/test/config.command.test.js
@@ -2,14 +2,12 @@
  * Test for the Config command.
  */
 const chai = require('chai')
-const delay = require('delay')
 const fs = require('fs-extra')
 const _ = require('lodash')
 const ini = require('ini')
 
 const testHelper = require('./common/testHelper')
 const testData = require('./common/testData')
-const testConfig = require('./common/testConfig')
 const logger = require('../src/common/logger')
 let { program } = require('../bin/topcoder-cli')
 
@@ -67,13 +65,13 @@ describe('Config Command Test', async function () {
       }
     )
     program.parse(localTestData.argsWithList)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(messages)).to.equal(localTestData.globalConfigWithUserCredentials)
   })
 
   it('success - add global config', async function () {
     program.parse(localTestData.argsWithAdd)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(content[0]).to.include('username=aaron2017')
   })
 
@@ -81,32 +79,32 @@ describe('Config Command Test', async function () {
     mocks.readFile.restore()
     mocks.readFile = testHelper.mockFunction(fs, 'readFile', () => { throw new Error() })
     program.parse(localTestData.argsWithAdd)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(content[0]).to.include('username=aaron2017')
   })
 
   it('success - unset global config', async function () {
     program.parse(localTestData.argsWithUnset)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(content[0]).to.include('password=xxx123')
     chai.expect(content[0]).to.not.include('username=TonyJ')
   })
 
   it('failure - add global config with invalid key', async function () {
     program.parse(localTestData.argsWithAddInvalidKey)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('Invalid key value.')
   })
 
   it('failure - add global config with extra values', async function () {
     program.parse(localTestData.argsWithExtraValues)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('Invalid number of values passed.')
   })
 
   it('failure - unset global config with non-existent key', async function () {
     program.parse(localTestData.argsWithUnsetNotExistentKey)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include(`${invalidConfig[0]} is not found in the config file`)
   })
 })

--- a/test/fetchArtifacts.command.test.js
+++ b/test/fetchArtifacts.command.test.js
@@ -2,14 +2,12 @@
  * Test for the FetchArtifacts command.
  */
 const chai = require('chai')
-const delay = require('delay')
 const path = require('path')
 const _ = require('lodash')
 
 const logger = require('../src/common/logger')
 const testHelper = require('./common/testHelper')
 const testData = require('./common/testData')
-const testConfig = require('./common/testConfig')
 let { program } = require('../bin/topcoder-cli')
 
 const submissionId = '4d38573f-404c-4c2f-90b1-a05ccd3fe860'
@@ -83,7 +81,7 @@ describe('FetchArtifacts Command Test', async function () {
 
   it('success - fetch artifacts to local', async function () {
     program.parse(localTestData.argsWithSubmissionId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(testData._variables.artifactDownloadInfo.length).to.equal(
       testData.responses.submissionAPI.searchArtifacts.artifacts.length
     )
@@ -98,7 +96,7 @@ describe('FetchArtifacts Command Test', async function () {
       mocks.returnEmptyRC.restore()
       mocks.mockRCConfig = testHelper.mockRCConfig({ submissionId, ...credentials })
       program.parse(localTestData.argsBasic)
-      await delay(testConfig.WAIT_TIME)
+      await testHelper.waitForCommandExit()
       chai.expect(testData._variables.artifactDownloadInfo.length).to.equal(
         testData.responses.submissionAPI.searchArtifacts.artifacts.length
       )
@@ -111,7 +109,7 @@ describe('FetchArtifacts Command Test', async function () {
       mocks.mockRCConfig = testHelper.mockRCConfig({ submissionId })
       mocks.mockGlobalConfig = testHelper.mockGlobalConfig(credentials)
       program.parse(localTestData.argsBasic)
-      await delay(testConfig.WAIT_TIME)
+      await testHelper.waitForCommandExit()
       chai.expect(testData._variables.artifactDownloadInfo.length).to.equal(
         testData.responses.submissionAPI.searchArtifacts.artifacts.length
       )
@@ -121,7 +119,7 @@ describe('FetchArtifacts Command Test', async function () {
 
   it('success - fetch artifacts to local with argument dev', async function () {
     program.parse(localTestData.argsWithDev)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(process.env.NODE_ENV).to.equal('dev')
     chai.expect(testData._variables.artifactDownloadInfo.length).to.equal(
       testData.responses.submissionAPI.searchArtifacts.artifacts.length
@@ -131,7 +129,7 @@ describe('FetchArtifacts Command Test', async function () {
 
   it('success - fetch artifacts to local with argument legacySubmissionId', async function () {
     program.parse(localTestData.argsWithLegacySubmissionId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(testData._variables.artifactDownloadInfo.length).to.equal(
       testData.responses.submissionAPI.searchArtifacts.artifacts.length
     )
@@ -140,14 +138,14 @@ describe('FetchArtifacts Command Test', async function () {
 
   it('success - show info if no artifacts found', async function () {
     program.parse(localTestData.argsWithSubmissionIdContainingZeroArtifacts)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.nth(messages, -2)).to.equal(`No artifact exists for submission with ID: ${testData.submissionIdWithZeroArtifacts}.`)
     chai.expect(_.nth(messages, -1)).to.equal('All Done!')
   })
 
   it('failure - fetch artifacts missing password', async function () {
     program.parse(localTestData.argsWithoutPassword)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('"username" missing required peer "password"')
   })
 
@@ -157,7 +155,7 @@ describe('FetchArtifacts Command Test', async function () {
     mocks.mockRCConfig = testHelper.mockRCConfig({ submissionId })
     mocks.mockGlobalConfig = testHelper.mockGlobalConfig(_.pick(testData.m2mConfig, ['m2m.client_secret']))
     program.parse(localTestData.argsBasic)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('m2m.client_id" is required')
   })
 
@@ -167,26 +165,26 @@ describe('FetchArtifacts Command Test', async function () {
     mocks.mockRCConfig = testHelper.mockRCConfig({ submissionId })
     mocks.mockGlobalConfig = testHelper.mockGlobalConfig(_.pick(testData.m2mConfig, ['m2m.client_id']))
     program.parse(localTestData.argsBasic)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('m2m.client_secret" is required')
   })
 
   it('failure - fetch artifacts without submissionId or legacySubmissionId', async function () {
     program.parse(localTestData.argsWithoutId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('"value" must contain at least one of [submissionId, legacySubmissionId]')
   })
 
   it('failure - fetch artifacts provided both submissionId and legacySubmissionId', async function () {
     program.parse(localTestData.argsWithBothIds)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('contains a conflict between exclusive peers [submissionId, legacySubmissionId]')
   })
 
   it('failure - it should handle possible request errors', async function () {
     testData._variables.needErrorResponse = true // instruct nock server to return 500
     program.parse(localTestData.argsWithSubmissionId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.nth(errorMessages, 0)).to.include('Couldn\'t download artifact')
   })
 
@@ -194,7 +192,7 @@ describe('FetchArtifacts Command Test', async function () {
     mocks.returnEmptyRC.restore()
     mocks.mockRCConfig = testHelper.mockRCConfig({ submissionId, ...testData.m2mConfig })
     program.parse(localTestData.argsWithSubmissionId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('contains a conflict between exclusive peers [username, m2m]')
   })
 })

--- a/test/fetchSubmissions.command.test.js
+++ b/test/fetchSubmissions.command.test.js
@@ -2,14 +2,12 @@
  * Test for the FetchSubmissions command.
  */
 const chai = require('chai')
-const delay = require('delay')
 const path = require('path')
 const _ = require('lodash')
 
 const logger = require('../src/common/logger')
 const testHelper = require('./common/testHelper')
 const testData = require('./common/testData')
-const testConfig = require('./common/testConfig')
 let { program } = require('../bin/topcoder-cli')
 
 const challengeId = '30095545'
@@ -89,7 +87,7 @@ describe('FetchSubmissions Command Test', async function () {
 
   it('success - fetch submissions to local', async function () {
     program.parse(localTestData.argsWithChallengeId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(testData._variables.submissionDownloadInfo.length).to.equal(
       testData.responses.submissionAPI.searchSubmissions.length
     )
@@ -104,7 +102,7 @@ describe('FetchSubmissions Command Test', async function () {
       mocks.returnEmptyRC.restore()
       mocks.mockRCConfig = testHelper.mockRCConfig({ challengeId, ...credentials })
       program.parse(localTestData.argsBasic)
-      await delay(testConfig.WAIT_TIME)
+      await testHelper.waitForCommandExit()
       chai.expect(testData._variables.submissionDownloadInfo.length).to.equal(
         testData.responses.submissionAPI.searchSubmissions.length
       )
@@ -117,7 +115,7 @@ describe('FetchSubmissions Command Test', async function () {
       mocks.mockRCConfig = testHelper.mockRCConfig({ challengeId })
       mocks.mockGlobalConfig = testHelper.mockGlobalConfig(credentials)
       program.parse(localTestData.argsBasic)
-      await delay(testConfig.WAIT_TIME)
+      await testHelper.waitForCommandExit()
       chai.expect(testData._variables.submissionDownloadInfo.length).to.equal(
         testData.responses.submissionAPI.searchSubmissions.length
       )
@@ -127,7 +125,7 @@ describe('FetchSubmissions Command Test', async function () {
 
   it('success - fetch submissions to local with argument dev', async function () {
     program.parse(localTestData.argsWithDev)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(process.env.NODE_ENV).to.equal('dev')
     chai.expect(testData._variables.submissionDownloadInfo.length).to.equal(
       testData.responses.submissionAPI.searchSubmissions.length
@@ -137,54 +135,54 @@ describe('FetchSubmissions Command Test', async function () {
 
   it('success - fetch submissions to local with argument latest', async function () {
     program.parse(localTestData.argsWithLatest)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(testData._variables.submissionDownloadInfo.length).to.equal(2)
     checkDownloadedSubmissions()
   })
 
   it('success - fetch submissions to local with argument memberId', async function () {
     program.parse(localTestData.argsWithMemberId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(testData._variables.submissionDownloadInfo.length).to.equal(1)
     checkDownloadedSubmissions()
   })
 
   it('success - fetch submissions to local with argument submissionId', async function () {
     program.parse(localTestData.argsWithSubmissionId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(testData._variables.submissionDownloadInfo.length).to.equal(1)
     checkDownloadedSubmissions()
   })
 
   it('success - show info if no submissions found', async function () {
     program.parse(localTestData.argsWithChallengeIdContainingZeroSubmissions)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.nth(messages, -2)).to.equal(`No submissions exists with specified filters for challenge with ID: ${testData.challengeIdWithZeroSubmissions}.`)
     chai.expect(_.nth(messages, -1)).to.equal('All Done!')
   })
 
   it('failure - fetch submissions without challengeId', async function () {
     program.parse(localTestData.argsWithoutChallengeId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('"challengeId" is required')
   })
 
   it('failure - fetch submissions with submissionId not belong to a challenge', async function () {
     program.parse(localTestData.argsWithSubmissionIdNotInChallenge)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('Submission doesn\'t belong to specified challenge.')
   })
 
   it('failure - it should handle possible request errors', async function () {
     testData._variables.needErrorResponse = true // instruct nock server to return 500
     program.parse(localTestData.argsWithSubmissionId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.nth(errorMessages, -2)).to.include(`Couldn't download submission with id: ${submissionId}`)
   })
 
   it('failure - fetch submissions missing password', async function () {
     program.parse(localTestData.argsWithoutPassword)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('"username" missing required peer "password"')
   })
 
@@ -194,7 +192,7 @@ describe('FetchSubmissions Command Test', async function () {
     mocks.mockRCConfig = testHelper.mockRCConfig({ challengeId })
     mocks.mockGlobalConfig = testHelper.mockGlobalConfig(_.pick(testData.m2mConfig, ['m2m.client_secret']))
     program.parse(localTestData.argsBasic)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('m2m.client_id" is required')
   })
 
@@ -204,7 +202,7 @@ describe('FetchSubmissions Command Test', async function () {
     mocks.mockRCConfig = testHelper.mockRCConfig({ challengeId })
     mocks.mockGlobalConfig = testHelper.mockGlobalConfig(_.pick(testData.m2mConfig, ['m2m.client_id']))
     program.parse(localTestData.argsBasic)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('m2m.client_secret" is required')
   })
 
@@ -212,19 +210,19 @@ describe('FetchSubmissions Command Test', async function () {
     mocks.returnEmptyRC.restore()
     mocks.mockRCConfig = testHelper.mockRCConfig({ challengeId, ...testData.m2mConfig })
     program.parse(localTestData.argsWithChallengeId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('contains a conflict between exclusive peers [username, m2m]')
   })
 
   it('failure - fetch submissions provided both submissionId and memberId', async function () {
     program.parse(localTestData.argsWithBothSubmissionIdAndMemberId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('Validation failed: "submissionId" conflict with forbidden peer "memberId"')
   })
 
   it('failure - fetch submissions provided both submissionId and latest', async function () {
     program.parse(localTestData.argsWithBothSubmissionIdAndLatest)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('Validation failed: "submissionId" conflict with forbidden peer "latest"')
   })
 })

--- a/test/pay.command.test.js
+++ b/test/pay.command.test.js
@@ -3,12 +3,10 @@
  */
 const chai = require('chai')
 const prompts = require('prompts')
-const delay = require('delay')
 const _ = require('lodash')
 
 const logger = require('../src/common/logger')
 const testHelper = require('./common/testHelper')
-const testConfig = require('./common/testConfig')
 const { program } = require('../bin/topcoder-cli')
 
 const localTestData = {
@@ -53,14 +51,14 @@ describe('Pay Command Test', async function () {
   it('prompts - it should capture user response', async function () {
     prompts.inject(Object.values(localTestData.injectedResponse))
     program.parse(localTestData.argsWithoutOption)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(messages[0]).to.eql(localTestData.injectedResponse)
   })
 
   it('prompts - it should capture user response with argument dev', async function () {
     prompts.inject(Object.values(localTestData.injectedResponse))
     program.parse(localTestData.argsWithDev)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(process.env.NODE_ENV).to.equal('dev')
     chai.expect(messages[0]).to.eql(localTestData.injectedResponse)
   })
@@ -68,7 +66,7 @@ describe('Pay Command Test', async function () {
   it('prompts - it should not ask for copilotPayment if the copilot argument is provided', async function () {
     prompts.inject(Object.values(localTestData.injectedResponse))
     program.parse(localTestData.argsWithOptionCopilot)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(messages[0]).to.eql(_.omit(localTestData.injectedResponse, 'copilotPayment'))
   })
 })

--- a/test/prepare.js
+++ b/test/prepare.js
@@ -21,6 +21,7 @@ const uuidExpr = '\\b[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a
 
 prepare(
   function (done) {
+    testHelper.spyActions()
     nock(/.com/)
       .persist()
       .filteringPath(path => {

--- a/test/submit.command.test.js
+++ b/test/submit.command.test.js
@@ -2,14 +2,12 @@
  * Test for the Submit command.
  */
 const chai = require('chai')
-const delay = require('delay')
 const _ = require('lodash')
 const mock = require('mock-require')
 
 const logger = require('../src/common/logger')
 const testHelper = require('./common/testHelper')
 const testData = require('./common/testData')
-const testConfig = require('./common/testConfig')
 let { program } = require('../bin/topcoder-cli')
 
 const challengeIds = '30095545'
@@ -24,9 +22,6 @@ const uploadedSubmissionInfo = {
   submission: { headers: { filename: `${memberId}.zip` }, body: contentInSubmission }
 }
 
-const localTestConfig = {
-  WAIT_TIME: testConfig.WAIT_TIME
-}
 const localTestData = {
   argsBasic: testHelper.buildArgs('submit'),
   argsWithChallengeIds: testHelper.buildArgs('submit', { ...testData.userCredentials, challengeIds }),
@@ -100,7 +95,7 @@ describe('Submit Command Test', async function () {
 
   it('success - upload a submission', async function () {
     program.parse(localTestData.argsWithChallengeIds)
-    await delay(localTestConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.nth(messages, -2)).to.include('[1/1] Uploaded Submission:')
     chai.expect(_.last(messages)).to.include('All Done!')
     chai.expect(testData._variables.uploadedSubmissionInfo[0]).to.eql(localTestData.uploadedSubmissionInfo)
@@ -114,7 +109,7 @@ describe('Submit Command Test', async function () {
       mocks.returnEmptyRC.restore()
       mocks.mockRCConfig = testHelper.mockRCConfig({ challengeIds: [challengeIds], memberId: localTestData.memberId, ...credentials })
       program.parse(localTestData.argsBasic)
-      await delay(localTestConfig.WAIT_TIME)
+      await testHelper.waitForCommandExit()
       chai.expect(_.nth(messages, -2)).to.include('[1/1] Uploaded Submission:')
       chai.expect(_.last(messages)).to.include('All Done!')
       chai.expect(testData._variables.uploadedSubmissionInfo[0]).to.eql(localTestData.uploadedSubmissionInfo)
@@ -126,7 +121,7 @@ describe('Submit Command Test', async function () {
       mocks.mockRCConfig = testHelper.mockRCConfig({ challengeIds: [challengeIds], memberId: localTestData.memberId })
       mocks.mockGlobalConfig = testHelper.mockGlobalConfig(credentials)
       program.parse(localTestData.argsBasic)
-      await delay(localTestConfig.WAIT_TIME)
+      await testHelper.waitForCommandExit()
       chai.expect(_.nth(messages, -2)).to.include('[1/1] Uploaded Submission:')
       chai.expect(_.last(messages)).to.include('All Done!')
       chai.expect(testData._variables.uploadedSubmissionInfo[0]).to.eql(localTestData.uploadedSubmissionInfo)
@@ -135,7 +130,7 @@ describe('Submit Command Test', async function () {
 
   it('success - upload a submission with argument dev', async function () {
     program.parse(localTestData.argsWithDev)
-    await delay(localTestConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(process.env.NODE_ENV).to.equal('dev')
     chai.expect(_.nth(messages, -2)).to.include('[1/1] Uploaded Submission:')
     chai.expect(_.last(messages)).to.include('All Done!')
@@ -145,19 +140,19 @@ describe('Submit Command Test', async function () {
   it('failure - it should handle possible request errors', async function () {
     testData._variables.needErrorResponse = true // instruct nock server to return 500
     program.parse(localTestData.argsWithChallengeIdsNotExist)
-    await delay(localTestConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include(`Error while uploading submission to challenge ID ${localTestData.challengeIdNotExist}`)
   })
 
   it('failure - upload a submission without challengeId', async function () {
     program.parse(localTestData.argsWithoutChallengeId)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('"challengeIds" is required')
   })
 
   it('failure - upload a submission missing password', async function () {
     program.parse(localTestData.argsWithoutPassword)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('"username" missing required peer "password"')
   })
 
@@ -165,7 +160,7 @@ describe('Submit Command Test', async function () {
     mocks.returnEmptyGlobalConfig.restore()
     mocks.mockGlobalConfig = testHelper.mockGlobalConfig(_.pick(testData.m2mConfig, ['m2m.client_secret']))
     program.parse(localTestData.argsWithOnlyChallengeIds)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('m2m.client_id" is required')
   })
 
@@ -173,7 +168,7 @@ describe('Submit Command Test', async function () {
     mocks.returnEmptyGlobalConfig.restore()
     mocks.mockGlobalConfig = testHelper.mockGlobalConfig(_.pick(testData.m2mConfig, ['m2m.client_id']))
     program.parse(localTestData.argsWithOnlyChallengeIds)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('m2m.client_secret" is required')
   })
 
@@ -181,7 +176,7 @@ describe('Submit Command Test', async function () {
     mocks.returnEmptyGlobalConfig.restore()
     mocks.mockGlobalConfig = testHelper.mockGlobalConfig(testData.m2mConfig)
     program.parse(localTestData.argsWithOnlyChallengeIds)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('Validation failed: "m2m" missing required peer "memberId"')
   })
 
@@ -189,7 +184,7 @@ describe('Submit Command Test', async function () {
     mocks.returnEmptyRC.restore()
     mocks.mockRCConfig = testHelper.mockRCConfig({ challengeIds: [challengeIds], memberId: localTestData.memberId, ...testData.m2mConfig })
     program.parse(localTestData.argsWithChallengeIds)
-    await delay(testConfig.WAIT_TIME)
+    await testHelper.waitForCommandExit()
     chai.expect(_.last(errorMessages)).to.include('contains a conflict between exclusive peers [username, m2m]')
   })
 })


### PR DESCRIPTION
By injecting an event emitter to every action we could have a fine control over the time when an action is completed. It is more fast and reliable than waiting for a time interval.

@sharathkumaranbu  let me know if the new change works for you without any additional configuration.
 Note that I make the change with self motivation so no payment required :)